### PR TITLE
Add reusable PageHeader and update page headers

### DIFF
--- a/src/components/CustomerManager.tsx
+++ b/src/components/CustomerManager.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PageHeader } from "./PageHeader";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
@@ -9,7 +10,8 @@ export function CustomerManager() {
   const updateCustomer = useMutation(api.customers.update);
 
   const [showForm, setShowForm] = useState(false);
-  const [editingCustomer, setEditingCustomer] = useState<Id<"customers"> | null>(null);
+  const [editingCustomer, setEditingCustomer] =
+    useState<Id<"customers"> | null>(null);
   const [formData, setFormData] = useState({
     companyName: "",
     contactName: "",
@@ -67,7 +69,7 @@ export function CustomerManager() {
       }
       resetForm();
     } catch (error) {
-      console.error('Failed to save customer:', error);
+      console.error("Failed to save customer:", error);
     }
   };
 
@@ -81,21 +83,18 @@ export function CustomerManager() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold text-gray-900">Customer Management</h2>
-        <button
-          onClick={() => setShowForm(true)}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-        >
-          Add New Customer
-        </button>
-      </div>
+      <PageHeader
+        title="Customer Management"
+        buttonLabel="Add New Customer"
+        icon="add"
+        onButtonClick={() => setShowForm(true)}
+      />
 
       {/* Customer Form */}
       {showForm && (
         <div className="bg-white p-6 rounded-lg shadow">
           <h3 className="text-lg font-medium text-gray-900 mb-4">
-            {editingCustomer ? 'Edit Customer' : 'Add New Customer'}
+            {editingCustomer ? "Edit Customer" : "Add New Customer"}
           </h3>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -106,7 +105,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.companyName}
-                  onChange={(e) => setFormData({ ...formData, companyName: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, companyName: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 />
@@ -118,7 +119,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.contactName}
-                  onChange={(e) => setFormData({ ...formData, contactName: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, contactName: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 />
@@ -130,7 +133,9 @@ export function CustomerManager() {
                 <input
                   type="email"
                   value={formData.email}
-                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, email: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 />
@@ -142,7 +147,9 @@ export function CustomerManager() {
                 <input
                   type="tel"
                   value={formData.phone}
-                  onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, phone: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                 />
               </div>
@@ -153,7 +160,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.address}
-                  onChange={(e) => setFormData({ ...formData, address: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, address: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                 />
               </div>
@@ -164,7 +173,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.city}
-                  onChange={(e) => setFormData({ ...formData, city: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, city: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                 />
               </div>
@@ -175,7 +186,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.country}
-                  onChange={(e) => setFormData({ ...formData, country: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, country: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                 />
               </div>
@@ -186,7 +199,9 @@ export function CustomerManager() {
                 <input
                   type="text"
                   value={formData.industry}
-                  onChange={(e) => setFormData({ ...formData, industry: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, industry: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                 />
               </div>
@@ -197,7 +212,9 @@ export function CustomerManager() {
               </label>
               <textarea
                 value={formData.notes}
-                onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, notes: e.target.value })
+                }
                 className="w-full border border-gray-300 rounded-md px-3 py-2"
                 rows={3}
               />
@@ -214,7 +231,7 @@ export function CustomerManager() {
                 type="submit"
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
               >
-                {editingCustomer ? 'Update' : 'Create'} Customer
+                {editingCustomer ? "Update" : "Create"} Customer
               </button>
             </div>
           </form>
@@ -259,10 +276,10 @@ export function CustomerManager() {
                   {customer.email}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  {customer.phone || '-'}
+                  {customer.phone || "-"}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  {customer.industry || '-'}
+                  {customer.industry || "-"}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   <button
@@ -276,7 +293,7 @@ export function CustomerManager() {
             ))}
           </tbody>
         </table>
-        
+
         {customers.length === 0 && (
           <div className="text-center py-12">
             <p className="text-gray-500">No customers found</p>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
+import { PageHeader } from "./PageHeader";
 
 export function Dashboard() {
   const stats = useQuery(api.quotes.getDashboardStats);
@@ -14,7 +15,8 @@ export function Dashboard() {
     );
   }
 
-  const conversionRate = stats.total > 0 ? (stats.converted / stats.total * 100).toFixed(1) : '0';
+  const conversionRate =
+    stats.total > 0 ? ((stats.converted / stats.total) * 100).toFixed(1) : "0";
   const recentQuotesList = recentQuotes.slice(0, 5);
 
   const handleSeedData = async () => {
@@ -22,37 +24,48 @@ export function Dashboard() {
       const result = await seedSampleData();
       alert(result);
     } catch (error) {
-      alert('Error seeding data: ' + error);
+      alert("Error seeding data: " + error);
     }
   };
 
   return (
     <div className="space-y-6">
       <div>
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-2xl font-bold text-gray-900">Dashboard</h2>
-          {stats.total === 0 && (
-            <button
-              onClick={handleSeedData}
-              className="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700"
-            >
-              Load Sample Data
-            </button>
-          )}
+        <div className="mb-6">
+          <PageHeader
+            title="Dashboard"
+            buttonLabel={stats.total === 0 ? "Load Sample Data" : undefined}
+            icon="download"
+            onButtonClick={stats.total === 0 ? handleSeedData : undefined}
+          />
         </div>
-        
+
         {/* Stats Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           <div className="bg-white p-6 rounded-lg shadow">
             <div className="flex items-center">
               <div className="p-2 bg-blue-100 rounded-lg">
-                <svg className="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                <svg
+                  className="w-6 h-6 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Total Quotes</p>
-                <p className="text-2xl font-semibold text-gray-900">{stats.total}</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Total Quotes
+                </p>
+                <p className="text-2xl font-semibold text-gray-900">
+                  {stats.total}
+                </p>
               </div>
             </div>
           </div>
@@ -60,13 +73,25 @@ export function Dashboard() {
           <div className="bg-white p-6 rounded-lg shadow">
             <div className="flex items-center">
               <div className="p-2 bg-green-100 rounded-lg">
-                <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                <svg
+                  className="w-6 h-6 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
                 <p className="text-sm font-medium text-gray-600">Converted</p>
-                <p className="text-2xl font-semibold text-gray-900">{stats.converted}</p>
+                <p className="text-2xl font-semibold text-gray-900">
+                  {stats.converted}
+                </p>
               </div>
             </div>
           </div>
@@ -74,13 +99,27 @@ export function Dashboard() {
           <div className="bg-white p-6 rounded-lg shadow">
             <div className="flex items-center">
               <div className="p-2 bg-purple-100 rounded-lg">
-                <svg className="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                <svg
+                  className="w-6 h-6 text-purple-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
-                <p className="text-sm font-medium text-gray-600">Conversion Rate</p>
-                <p className="text-2xl font-semibold text-gray-900">{conversionRate}%</p>
+                <p className="text-sm font-medium text-gray-600">
+                  Conversion Rate
+                </p>
+                <p className="text-2xl font-semibold text-gray-900">
+                  {conversionRate}%
+                </p>
               </div>
             </div>
           </div>
@@ -88,8 +127,18 @@ export function Dashboard() {
           <div className="bg-white p-6 rounded-lg shadow">
             <div className="flex items-center">
               <div className="p-2 bg-yellow-100 rounded-lg">
-                <svg className="w-6 h-6 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
+                <svg
+                  className="w-6 h-6 text-yellow-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
+                  />
                 </svg>
               </div>
               <div className="ml-4">
@@ -105,47 +154,71 @@ export function Dashboard() {
         {/* Status Overview */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Quote Status Overview</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              Quote Status Overview
+            </h3>
             <div className="space-y-3">
               <div className="flex justify-between items-center">
                 <span className="text-sm text-gray-600">Draft</span>
-                <span className="text-sm font-medium text-gray-900">{stats.draft}</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {stats.draft}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-sm text-gray-600">Sent</span>
-                <span className="text-sm font-medium text-gray-900">{stats.sent}</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {stats.sent}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-sm text-gray-600">Approved</span>
-                <span className="text-sm font-medium text-gray-900">{stats.approved}</span>
+                <span className="text-sm font-medium text-gray-900">
+                  {stats.approved}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-sm text-gray-600">Converted</span>
-                <span className="text-sm font-medium text-green-600">{stats.converted}</span>
+                <span className="text-sm font-medium text-green-600">
+                  {stats.converted}
+                </span>
               </div>
             </div>
           </div>
 
           <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Recent Quotes</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              Recent Quotes
+            </h3>
             <div className="space-y-3">
               {recentQuotesList.map((quote) => (
-                <div key={quote._id} className="flex justify-between items-center">
+                <div
+                  key={quote._id}
+                  className="flex justify-between items-center"
+                >
                   <div>
-                    <p className="text-sm font-medium text-gray-900">{quote.quoteNumber}</p>
-                    <p className="text-xs text-gray-500">{quote.customer?.companyName}</p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {quote.quoteNumber}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {quote.customer?.companyName}
+                    </p>
                   </div>
                   <div className="text-right">
                     <p className="text-sm font-medium text-gray-900">
                       ${quote.totalAmount.toLocaleString()}
                     </p>
-                    <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${
-                      quote.status === 'converted' ? 'bg-green-100 text-green-800' :
-                      quote.status === 'sent' ? 'bg-blue-100 text-blue-800' :
-                      quote.status === 'draft' ? 'bg-gray-100 text-gray-800' :
-                      'bg-yellow-100 text-yellow-800'
-                    }`}>
-                      {quote.status.replace('_', ' ')}
+                    <span
+                      className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${
+                        quote.status === "converted"
+                          ? "bg-green-100 text-green-800"
+                          : quote.status === "sent"
+                            ? "bg-blue-100 text-blue-800"
+                            : quote.status === "draft"
+                              ? "bg-gray-100 text-gray-800"
+                              : "bg-yellow-100 text-yellow-800"
+                      }`}
+                    >
+                      {quote.status.replace("_", " ")}
                     </span>
                   </div>
                 </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface PageHeaderProps {
+  title: string;
+  buttonLabel?: string;
+  icon?: string;
+  onButtonClick?: () => void;
+}
+
+export function PageHeader({
+  title,
+  buttonLabel,
+  icon = "save",
+  onButtonClick,
+}: PageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <h2 className="text-3xl font-bold">{title}</h2>
+      {buttonLabel && (
+        <button
+          onClick={onButtonClick}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg flex items-center gap-2"
+          style={{ minWidth: 180 }}
+        >
+          <span className="material-icons">{icon}</span>
+          {buttonLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProductManager.tsx
+++ b/src/components/ProductManager.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PageHeader } from "./PageHeader";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
@@ -6,51 +7,64 @@ import { Id } from "../../convex/_generated/dataModel";
 const PRODUCT_CATEGORIES = {
   "Material & Hardware": [
     "Conveyors",
-    "DWS Systems", 
+    "DWS Systems",
     "Singulators",
     "Crossbelt/Loop Sorters",
     "Barcode/QR Readers",
     "Electrical Panels & PLCs",
-    "Structural Supports"
+    "Structural Supports",
   ],
   "Manpower / Engineering Services": [
     "Design & Engineering",
-    "Project Management", 
+    "Project Management",
     "Workshop Assembly",
     "On-site Installation",
     "Commissioning & Testing",
-    "Operator Training"
+    "Operator Training",
   ],
   "Logistics & Transport": [
     "Freight Services",
     "Customs & Import Taxes",
     "Packaging & Handling",
-    "Insurance"
+    "Insurance",
   ],
   "Software & Control Systems": [
     "WCS Software",
     "PLC Programming & Logic",
-    "HMI Design", 
-    "Data Integration"
+    "HMI Design",
+    "Data Integration",
   ],
   "After-Sales Services & Support": [
     "Extended Warranty",
     "Spare Parts Kits",
     "Remote Diagnostics",
-    "Hotline / On-call Support"
+    "Hotline / On-call Support",
   ],
   "Optional Systems & Modules": [
     "Telescopic Conveyors",
     "Additional Induction Lines",
     "Extra Store Output/Sorting Chutes",
     "Redundancy Systems",
-    "Labeling Machines"
-  ]
+    "Labeling Machines",
+  ],
 };
 
 const UNITS = [
-  "unit", "meter", "hour", "system", "license", "kit", "month", "year", 
-  "km", "kg", "container", "shipment", "destination", "chute", "line"
+  "unit",
+  "meter",
+  "hour",
+  "system",
+  "license",
+  "kit",
+  "month",
+  "year",
+  "km",
+  "kg",
+  "container",
+  "shipment",
+  "destination",
+  "chute",
+  "line",
 ];
 
 export function ProductManager() {
@@ -59,12 +73,14 @@ export function ProductManager() {
   const updateProduct = useMutation(api.products.update);
 
   const [showForm, setShowForm] = useState(false);
-  const [editingProduct, setEditingProduct] = useState<Id<"products"> | null>(null);
+  const [editingProduct, setEditingProduct] = useState<Id<"products"> | null>(
+    null,
+  );
   const [selectedCategory, setSelectedCategory] = useState<string>("");
   const [filterCategory, setFilterCategory] = useState<string>("all");
   const [filterSubcategory, setFilterSubcategory] = useState<string>("all");
   const [searchTerm, setSearchTerm] = useState("");
-  
+
   const [formData, setFormData] = useState({
     name: "",
     description: "",
@@ -126,25 +142,40 @@ export function ProductManager() {
       }
       resetForm();
     } catch (error) {
-      console.error('Failed to save product:', error);
+      console.error("Failed to save product:", error);
     }
   };
 
   // Filter products based on search and category filters
-  const filteredProducts = products?.filter(product => {
-    const matchesSearch = product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         product.description.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = filterCategory === "all" || product.category === filterCategory;
-    const matchesSubcategory = filterSubcategory === "all" || product.subcategory === filterSubcategory;
-    
-    return matchesSearch && matchesCategory && matchesSubcategory;
-  }) || [];
+  const filteredProducts =
+    products?.filter((product) => {
+      const matchesSearch =
+        product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        product.description.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesCategory =
+        filterCategory === "all" || product.category === filterCategory;
+      const matchesSubcategory =
+        filterSubcategory === "all" ||
+        product.subcategory === filterSubcategory;
+
+      return matchesSearch && matchesCategory && matchesSubcategory;
+    }) || [];
 
   // Get unique categories and subcategories for filters
-  const availableCategories = [...new Set(products?.map(p => p.category) || [])];
-  const availableSubcategories = filterCategory === "all" 
-    ? [...new Set(products?.map(p => p.subcategory).filter(Boolean) || [])]
-    : [...new Set(products?.filter(p => p.category === filterCategory).map(p => p.subcategory).filter(Boolean) || [])];
+  const availableCategories = [
+    ...new Set(products?.map((p) => p.category) || []),
+  ];
+  const availableSubcategories =
+    filterCategory === "all"
+      ? [...new Set(products?.map((p) => p.subcategory).filter(Boolean) || [])]
+      : [
+          ...new Set(
+            products
+              ?.filter((p) => p.category === filterCategory)
+              .map((p) => p.subcategory)
+              .filter(Boolean) || [],
+          ),
+        ];
 
   if (products === undefined) {
     return (
@@ -156,44 +187,49 @@ export function ProductManager() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-2xl font-bold text-gray-900">Product Catalog</h2>
-          <p className="text-gray-600 mt-1">Manage your intralogistics products and services</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700"
-        >
-          Add New Product
-        </button>
-      </div>
+      <PageHeader
+        title="Product Catalog"
+        buttonLabel="Add New Product"
+        icon="add"
+        onButtonClick={() => setShowForm(true)}
+      />
+      <p className="text-gray-600 mt-1">
+        Manage your intralogistics products and services
+      </p>
 
       {/* Category Overview Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {Object.entries(PRODUCT_CATEGORIES).map(([category, subcategories]) => {
-          const categoryProducts = products?.filter(p => p.category === category) || [];
-          const categoryIcon = {
-            "Material & Hardware": "🧱",
-            "Manpower / Engineering Services": "👷",
-            "Logistics & Transport": "🚛",
-            "Software & Control Systems": "📊",
-            "After-Sales Services & Support": "🔧",
-            "Optional Systems & Modules": "➕"
-          }[category] || "📦";
+          const categoryProducts =
+            products?.filter((p) => p.category === category) || [];
+          const categoryIcon =
+            {
+              "Material & Hardware": "🧱",
+              "Manpower / Engineering Services": "👷",
+              "Logistics & Transport": "🚛",
+              "Software & Control Systems": "📊",
+              "After-Sales Services & Support": "🔧",
+              "Optional Systems & Modules": "➕",
+            }[category] || "📦";
 
           return (
-            <div key={category} className="bg-white p-4 rounded-lg shadow border">
+            <div
+              key={category}
+              className="bg-white p-4 rounded-lg shadow border"
+            >
               <div className="flex items-center mb-2">
                 <span className="text-2xl mr-3">{categoryIcon}</span>
                 <div>
                   <h3 className="font-medium text-gray-900">{category}</h3>
-                  <p className="text-sm text-gray-500">{categoryProducts.length} products</p>
+                  <p className="text-sm text-gray-500">
+                    {categoryProducts.length} products
+                  </p>
                 </div>
               </div>
               <div className="text-xs text-gray-400">
                 {subcategories.slice(0, 3).join(", ")}
-                {subcategories.length > 3 && ` +${subcategories.length - 3} more`}
+                {subcategories.length > 3 &&
+                  ` +${subcategories.length - 3} more`}
               </div>
             </div>
           );
@@ -228,8 +264,10 @@ export function ProductManager() {
               className="w-full border border-gray-300 rounded-md px-3 py-2"
             >
               <option value="all">All Categories</option>
-              {availableCategories.map(category => (
-                <option key={category} value={category}>{category}</option>
+              {availableCategories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
               ))}
             </select>
           </div>
@@ -244,8 +282,10 @@ export function ProductManager() {
               disabled={filterCategory === "all"}
             >
               <option value="all">All Subcategories</option>
-              {availableSubcategories.map(subcategory => (
-                <option key={subcategory} value={subcategory}>{subcategory}</option>
+              {availableSubcategories.map((subcategory) => (
+                <option key={subcategory} value={subcategory}>
+                  {subcategory}
+                </option>
               ))}
             </select>
           </div>
@@ -261,7 +301,7 @@ export function ProductManager() {
       {showForm && (
         <div className="bg-white p-6 rounded-lg shadow">
           <h3 className="text-lg font-medium text-gray-900 mb-4">
-            {editingProduct ? 'Edit Product' : 'Add New Product'}
+            {editingProduct ? "Edit Product" : "Add New Product"}
           </h3>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -272,7 +312,9 @@ export function ProductManager() {
                 <input
                   type="text"
                   value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, name: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 />
@@ -288,8 +330,10 @@ export function ProductManager() {
                   required
                 >
                   <option value="">Select Category</option>
-                  {Object.keys(PRODUCT_CATEGORIES).map(category => (
-                    <option key={category} value={category}>{category}</option>
+                  {Object.keys(PRODUCT_CATEGORIES).map((category) => (
+                    <option key={category} value={category}>
+                      {category}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -299,14 +343,21 @@ export function ProductManager() {
                 </label>
                 <select
                   value={formData.subcategory}
-                  onChange={(e) => setFormData({ ...formData, subcategory: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, subcategory: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   disabled={!selectedCategory}
                 >
                   <option value="">Select Subcategory</option>
-                  {selectedCategory && PRODUCT_CATEGORIES[selectedCategory as keyof typeof PRODUCT_CATEGORIES]?.map(subcategory => (
-                    <option key={subcategory} value={subcategory}>{subcategory}</option>
-                  ))}
+                  {selectedCategory &&
+                    PRODUCT_CATEGORIES[
+                      selectedCategory as keyof typeof PRODUCT_CATEGORIES
+                    ]?.map((subcategory) => (
+                      <option key={subcategory} value={subcategory}>
+                        {subcategory}
+                      </option>
+                    ))}
                 </select>
               </div>
               <div>
@@ -317,7 +368,12 @@ export function ProductManager() {
                   type="number"
                   step="0.01"
                   value={formData.basePrice}
-                  onChange={(e) => setFormData({ ...formData, basePrice: parseFloat(e.target.value) || 0 })}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      basePrice: parseFloat(e.target.value) || 0,
+                    })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 />
@@ -328,12 +384,16 @@ export function ProductManager() {
                 </label>
                 <select
                   value={formData.unit}
-                  onChange={(e) => setFormData({ ...formData, unit: e.target.value })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, unit: e.target.value })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2"
                   required
                 >
-                  {UNITS.map(unit => (
-                    <option key={unit} value={unit}>{unit}</option>
+                  {UNITS.map((unit) => (
+                    <option key={unit} value={unit}>
+                      {unit}
+                    </option>
                   ))}
                 </select>
               </div>
@@ -342,10 +402,15 @@ export function ProductManager() {
                   type="checkbox"
                   id="isActive"
                   checked={formData.isActive}
-                  onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
+                  onChange={(e) =>
+                    setFormData({ ...formData, isActive: e.target.checked })
+                  }
                   className="mr-2"
                 />
-                <label htmlFor="isActive" className="text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="isActive"
+                  className="text-sm font-medium text-gray-700"
+                >
                   Active Product
                 </label>
               </div>
@@ -356,7 +421,9 @@ export function ProductManager() {
               </label>
               <textarea
                 value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, description: e.target.value })
+                }
                 className="w-full border border-gray-300 rounded-md px-3 py-2"
                 rows={3}
                 required
@@ -368,7 +435,9 @@ export function ProductManager() {
               </label>
               <textarea
                 value={formData.specifications}
-                onChange={(e) => setFormData({ ...formData, specifications: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, specifications: e.target.value })
+                }
                 className="w-full border border-gray-300 rounded-md px-3 py-2"
                 rows={3}
                 placeholder="Technical specifications, dimensions, capabilities, etc."
@@ -386,7 +455,7 @@ export function ProductManager() {
                 type="submit"
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
               >
-                {editingProduct ? 'Update' : 'Create'} Product
+                {editingProduct ? "Update" : "Create"} Product
               </button>
             </div>
           </form>
@@ -424,17 +493,27 @@ export function ProductManager() {
                 <tr key={product._id} className="hover:bg-gray-50">
                   <td className="px-6 py-4">
                     <div>
-                      <div className="text-sm font-medium text-gray-900">{product.name}</div>
-                      <div className="text-sm text-gray-500">{product.description}</div>
+                      <div className="text-sm font-medium text-gray-900">
+                        {product.name}
+                      </div>
+                      <div className="text-sm text-gray-500">
+                        {product.description}
+                      </div>
                       {product.specifications && (
-                        <div className="text-xs text-gray-400 mt-1">{product.specifications}</div>
+                        <div className="text-xs text-gray-400 mt-1">
+                          {product.specifications}
+                        </div>
                       )}
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-gray-900">{product.category}</div>
+                    <div className="text-sm text-gray-900">
+                      {product.category}
+                    </div>
                     {product.subcategory && (
-                      <div className="text-xs text-gray-500">{product.subcategory}</div>
+                      <div className="text-xs text-gray-500">
+                        {product.subcategory}
+                      </div>
                     )}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -444,12 +523,14 @@ export function ProductManager() {
                     {product.unit}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                      product.isActive 
-                        ? 'bg-green-100 text-green-800' 
-                        : 'bg-red-100 text-red-800'
-                    }`}>
-                      {product.isActive ? 'Active' : 'Inactive'}
+                    <span
+                      className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                        product.isActive
+                          ? "bg-green-100 text-green-800"
+                          : "bg-red-100 text-red-800"
+                      }`}
+                    >
+                      {product.isActive ? "Active" : "Inactive"}
                     </span>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
@@ -465,12 +546,14 @@ export function ProductManager() {
             </tbody>
           </table>
         </div>
-        
+
         {filteredProducts.length === 0 && (
           <div className="text-center py-12">
             <p className="text-gray-500">
-              {searchTerm || filterCategory !== "all" || filterSubcategory !== "all" 
-                ? "No products match your search criteria" 
+              {searchTerm ||
+              filterCategory !== "all" ||
+              filterSubcategory !== "all"
+                ? "No products match your search criteria"
                 : "No products found"}
             </p>
           </div>

--- a/src/components/QuoteBuilder.tsx
+++ b/src/components/QuoteBuilder.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { PageHeader } from "./PageHeader";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
@@ -75,7 +76,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
       });
       onBack();
     } catch (error) {
-      console.error('Failed to create quote:', error);
+      console.error("Failed to create quote:", error);
     } finally {
       setIsSubmitting(false);
     }
@@ -92,28 +93,20 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
   return (
     <div className="bg-white min-h-screen text-gray-900 p-6 flex justify-center items-start">
       <div className="w-full max-w-4xl">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-3xl font-bold">Create New Quotation</h2>
-          <button
-            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg flex items-center gap-2"
-            style={{ minWidth: 180 }}
-          >
-            <span className="material-icons">save</span>
-            Save Quotation
-          </button>
-        </div>
+        <PageHeader title="Create New Quotation" buttonLabel="Save Quotation" />
         {/* Tab Navigation */}
-        <div 
+        <div
           className="flex bg-gray-100 rounded-lg overflow-hidden mb-6"
           style={{
-            fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-            color: 'rgb(17 24 39)',
-            boxSizing: 'border-box',
+            fontFamily:
+              'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            color: "rgb(17 24 39)",
+            boxSizing: "border-box",
             borderWidth: 0,
-            borderStyle: 'solid',
-            borderColor: '#e5e7eb',
-            width: '100%',
-            maxWidth: '56rem'
+            borderStyle: "solid",
+            borderColor: "#e5e7eb",
+            width: "100%",
+            maxWidth: "56rem",
           }}
         >
           {TABS.map((tab, idx) => (
@@ -126,12 +119,13 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
               }`}
               onClick={() => setActiveTab(idx)}
               style={{
-                fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
-                color: 'rgb(17 24 39)',
-                boxSizing: 'border-box',
+                fontFamily:
+                  'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+                color: "rgb(17 24 39)",
+                boxSizing: "border-box",
                 borderWidth: 0,
-                borderStyle: 'solid',
-                borderColor: '#e5e7eb'
+                borderStyle: "solid",
+                borderColor: "#e5e7eb",
               }}
             >
               {tab}
@@ -140,24 +134,38 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
         </div>
         {/* Tab Content */}
         {activeTab === 0 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             {/* Quotation Details */}
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Quotation Details</h3>
-              <p className="text-gray-500 text-sm mb-4">Basic information about the quotation</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Basic information about the quotation
+              </p>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
                 <div className="col-span-2">
-                  <label className="block text-sm mb-1">Quotation Number *</label>
+                  <label className="block text-sm mb-1">
+                    Quotation Number *
+                  </label>
                   <div className="flex gap-2">
                     <input
                       className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                       value={quotationNumber}
-                      onChange={e => setQuotationNumber(e.target.value)}
+                      onChange={(e) => setQuotationNumber(e.target.value)}
                     />
                     <button
                       type="button"
                       className="bg-gray-200 text-gray-700 px-3 py-2 rounded"
-                      onClick={() => setQuotationNumber("QTN-2025-" + Math.floor(1000 + Math.random() * 9000))}
+                      onClick={() =>
+                        setQuotationNumber(
+                          "QTN-2025-" + Math.floor(1000 + Math.random() * 9000),
+                        )
+                      }
                     >
                       Generate
                     </button>
@@ -169,17 +177,19 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                     type="text"
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={issueDate}
-                    onChange={e => setIssueDate(e.target.value)}
+                    onChange={(e) => setIssueDate(e.target.value)}
                   />
                 </div>
               </div>
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div>
-                  <label className="block text-sm mb-1">Validity Period *</label>
+                  <label className="block text-sm mb-1">
+                    Validity Period *
+                  </label>
                   <select
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={validity}
-                    onChange={e => setValidity(e.target.value)}
+                    onChange={(e) => setValidity(e.target.value)}
                   >
                     <option>30 days</option>
                     <option>60 days</option>
@@ -191,7 +201,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <select
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={currency}
-                    onChange={e => setCurrency(e.target.value)}
+                    onChange={(e) => setCurrency(e.target.value)}
                   >
                     <option>US Dollar ($)</option>
                     <option>Euro (€)</option>
@@ -202,15 +212,19 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
             </div>
             {/* Company Information */}
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
-              <h3 className="text-lg font-semibold mb-2">Company Information</h3>
-              <p className="text-gray-500 text-sm mb-4">Enter your company details that will appear on the quotation</p>
+              <h3 className="text-lg font-semibold mb-2">
+                Company Information
+              </h3>
+              <p className="text-gray-500 text-sm mb-4">
+                Enter your company details that will appear on the quotation
+              </p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                 <div>
                   <label className="block text-sm mb-1">Company Name *</label>
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={companyName}
-                    onChange={e => setCompanyName(e.target.value)}
+                    onChange={(e) => setCompanyName(e.target.value)}
                     placeholder="Your Company Name"
                   />
                 </div>
@@ -219,7 +233,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={companyLogo}
-                    onChange={e => setCompanyLogo(e.target.value)}
+                    onChange={(e) => setCompanyLogo(e.target.value)}
                     placeholder="http://example.com/logo.png"
                   />
                 </div>
@@ -230,7 +244,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={companyAddress}
-                    onChange={e => setCompanyAddress(e.target.value)}
+                    onChange={(e) => setCompanyAddress(e.target.value)}
                     placeholder="123 Business St, City, Country"
                   />
                 </div>
@@ -239,7 +253,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={contactPhone}
-                    onChange={e => setContactPhone(e.target.value)}
+                    onChange={(e) => setContactPhone(e.target.value)}
                     placeholder="+1 (555) 123-4567"
                   />
                 </div>
@@ -250,7 +264,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={contactEmail}
-                    onChange={e => setContactEmail(e.target.value)}
+                    onChange={(e) => setContactEmail(e.target.value)}
                     placeholder="contact@yourcompany.com"
                   />
                 </div>
@@ -259,7 +273,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={companyWebsite}
-                    onChange={e => setCompanyWebsite(e.target.value)}
+                    onChange={(e) => setCompanyWebsite(e.target.value)}
                     placeholder="https://yourcompany.com"
                   />
                 </div>
@@ -268,14 +282,16 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
             {/* Client Information */}
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Client Information</h3>
-              <p className="text-gray-500 text-sm mb-4">Enter the client details for this quotation</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Enter the client details for this quotation
+              </p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                 <div>
                   <label className="block text-sm mb-1">Client Name *</label>
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={clientName}
-                    onChange={e => setClientName(e.target.value)}
+                    onChange={(e) => setClientName(e.target.value)}
                     placeholder="Client Company Name"
                   />
                 </div>
@@ -284,7 +300,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={clientContact}
-                    onChange={e => setClientContact(e.target.value)}
+                    onChange={(e) => setClientContact(e.target.value)}
                     placeholder="John Smith"
                   />
                 </div>
@@ -295,7 +311,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={clientAddress}
-                    onChange={e => setClientAddress(e.target.value)}
+                    onChange={(e) => setClientAddress(e.target.value)}
                     placeholder="456 Client St, City, Country"
                   />
                 </div>
@@ -304,7 +320,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   <input
                     className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                     value={clientEmail}
-                    onChange={e => setClientEmail(e.target.value)}
+                    onChange={(e) => setClientEmail(e.target.value)}
                     placeholder="client@example.com"
                   />
                 </div>
@@ -314,33 +330,51 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                 <input
                   className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                   value={projectReference}
-                  onChange={e => setProjectReference(e.target.value)}
+                  onChange={(e) => setProjectReference(e.target.value)}
                   placeholder="Automated Warehouse System for Client"
                 />
               </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" disabled>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                disabled
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(1)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(1)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 1 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
-              <h3 className="text-lg font-semibold mb-2">Introduction & Scope of Work</h3>
-              <p className="text-gray-500 text-sm mb-4">Provide an overview of what the quotation covers</p>
+              <h3 className="text-lg font-semibold mb-2">
+                Introduction & Scope of Work
+              </h3>
+              <p className="text-gray-500 text-sm mb-4">
+                Provide an overview of what the quotation covers
+              </p>
               <div className="mb-4">
                 <label className="block text-sm mb-1">Project Summary</label>
                 <textarea
                   className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                   rows={2}
                   value={projectSummary}
-                  onChange={e => setProjectSummary(e.target.value)}
+                  onChange={(e) => setProjectSummary(e.target.value)}
                   placeholder="Brief description of the project or service (e.g., Supply and installation of conveyor systems for Client's Facility)"
                 />
               </div>
@@ -350,7 +384,7 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                   rows={2}
                   value={scopeOfSupply}
-                  onChange={e => setScopeOfSupply(e.target.value)}
+                  onChange={(e) => setScopeOfSupply(e.target.value)}
                   placeholder="High-level list of deliverables (e.g., equipment, services, installation, training)"
                 />
               </div>
@@ -360,46 +394,69 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
                   rows={2}
                   value={keyAssumptions}
-                  onChange={e => setKeyAssumptions(e.target.value)}
+                  onChange={(e) => setKeyAssumptions(e.target.value)}
                   placeholder="Any assumptions affecting pricing (e.g., 'Excludes local taxes' or 'Assumes client provides site access')"
                 />
               </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(0)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(0)}
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(2)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(2)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 2 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
-              <h3 className="text-lg font-semibold mb-2">Material & Equipment Costs</h3>
-              <p className="text-gray-500 text-sm mb-4">Itemized list of all materials and equipment</p>
+              <h3 className="text-lg font-semibold mb-2">
+                Material & Equipment Costs
+              </h3>
+              <p className="text-gray-500 text-sm mb-4">
+                Itemized list of all materials and equipment
+              </p>
               {/* Subcategory Tabs */}
               <div className="mb-4">
                 <div className="flex gap-2 mb-4">
-                  {['Mechanical', 'Electrical', 'Hardware', 'Additionals'].map((cat, idx) => (
-                    <button
-                      key={cat}
-                      type="button"
-                      className={`px-4 py-1 rounded font-medium text-sm transition-colors focus:outline-none ${
-                        selectedSubcategory === cat
-                          ? 'bg-blue-600 text-white'
-                          : 'bg-gray-200 text-gray-700 hover:bg-blue-100'
-                      }`}
-                      onClick={() => setSelectedSubcategory(cat)}
-                    >
-                      {cat}
-                    </button>
-                  ))}
+                  {["Mechanical", "Electrical", "Hardware", "Additionals"].map(
+                    (cat, idx) => (
+                      <button
+                        key={cat}
+                        type="button"
+                        className={`px-4 py-1 rounded font-medium text-sm transition-colors focus:outline-none ${
+                          selectedSubcategory === cat
+                            ? "bg-blue-600 text-white"
+                            : "bg-gray-200 text-gray-700 hover:bg-blue-100"
+                        }`}
+                        onClick={() => setSelectedSubcategory(cat)}
+                      >
+                        {cat}
+                      </button>
+                    ),
+                  )}
                 </div>
                 <div className="flex gap-2 mb-4">
-                  <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2"
+                  >
                     <span className="material-icons">add</span> Add Item
                   </button>
                 </div>
@@ -419,12 +476,18 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                     <tbody>
                       {/* Example row */}
                       <tr className="border-b border-gray-200">
-                        <td className="px-4 py-2 font-semibold">steel construction</td>
+                        <td className="px-4 py-2 font-semibold">
+                          steel construction
+                        </td>
                         <td className="px-4 py-2">mechanical</td>
                         <td className="px-4 py-2">N/A</td>
                         <td className="px-4 py-2">ABC Steel</td>
                         <td className="px-4 py-2">$12.00</td>
-                        <td className="px-4 py-2"><button className="bg-blue-600 text-white px-3 py-1 rounded">Select</button></td>
+                        <td className="px-4 py-2">
+                          <button className="bg-blue-600 text-white px-3 py-1 rounded">
+                            Select
+                          </button>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -432,95 +495,184 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
               </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(1)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(1)}
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(3)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(3)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 3 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Manpower Costs</h3>
-              <p className="text-gray-500 text-sm mb-4">Labor costs by project phase or task</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Labor costs by project phase or task
+              </p>
               <div className="flex gap-2 mb-4">
-                <button type="button" className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">storage</span> From Catalog
                 </button>
-                <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">add</span> Add Item
                 </button>
               </div>
-              <div className="text-gray-400 text-center py-8">No manpower costs added yet. Click "Add Item" to get started.</div>
+              <div className="text-gray-400 text-center py-8">
+                No manpower costs added yet. Click "Add Item" to get started.
+              </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(2)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(2)}
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(4)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(4)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 4 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Logistic Costs</h3>
-              <p className="text-gray-500 text-sm mb-4">Transportation and logistics expenses</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Transportation and logistics expenses
+              </p>
               <div className="flex gap-2 mb-4">
-                <button type="button" className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">storage</span> From Catalog
                 </button>
-                <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">add</span> Add Item
                 </button>
               </div>
-              <div className="text-gray-400 text-center py-8">No logistic costs added yet. Click "Add Item" to get started.</div>
+              <div className="text-gray-400 text-center py-8">
+                No logistic costs added yet. Click "Add Item" to get started.
+              </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(3)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(3)}
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(5)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(5)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 5 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Additional Costs</h3>
-              <p className="text-gray-500 text-sm mb-4">Taxes, duties, optional items, and contingencies</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Taxes, duties, optional items, and contingencies
+              </p>
               <div className="flex gap-2 mb-4">
-                <button type="button" className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-gray-100 border border-gray-300 text-gray-700 px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">storage</span> From Catalog
                 </button>
-                <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2">
+                <button
+                  type="button"
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center gap-2"
+                >
                   <span className="material-icons">add</span> Add Item
                 </button>
               </div>
-              <div className="text-gray-400 text-center py-8">No additional costs added yet. Click "Add Item" to get started.</div>
+              <div className="text-gray-400 text-center py-8">
+                No additional costs added yet. Click "Add Item" to get started.
+              </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(4)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(4)}
+              >
                 Previous
               </button>
-              <button type="button" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" onClick={() => setActiveTab(6)}>
+              <button
+                type="button"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                onClick={() => setActiveTab(6)}
+              >
                 Next
               </button>
             </div>
           </form>
         )}
         {activeTab === 6 && (
-          <form className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl" style={{ fontFamily: 'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"' }} onSubmit={handleSubmit}>
+          <form
+            className="space-y-8 p-6 font-[Inter] bg-white text-gray-900 w-full max-w-4xl"
+            style={{
+              fontFamily:
+                'Inter Variable, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+            }}
+            onSubmit={handleSubmit}
+          >
             <div className="bg-white p-6 rounded-lg mb-6 border border-gray-200">
               <h3 className="text-lg font-semibold mb-2">Total Project Cost</h3>
-              <p className="text-gray-500 text-sm mb-4">Summary of all costs for the project</p>
+              <p className="text-gray-500 text-sm mb-4">
+                Summary of all costs for the project
+              </p>
               <div className="overflow-x-auto mb-6">
                 <table className="min-w-full text-sm text-left">
                   <thead className="bg-gray-100 text-gray-700">
@@ -549,33 +701,86 @@ export function QuoteBuilder({ onBack }: QuoteBuilderProps) {
                   </tbody>
                 </table>
                 <div className="bg-gray-100 text-gray-900 text-xl font-bold p-4 mt-4 rounded-lg text-center">
-                  Grand Total<br />$0,00
+                  Grand Total
+                  <br />
+                  $0,00
                 </div>
               </div>
               {/* Terms and Conditions Section */}
               <div className="mb-6">
-                <h4 className="text-md font-semibold mb-2">Terms and Conditions</h4>
+                <h4 className="text-md font-semibold mb-2">
+                  Terms and Conditions
+                </h4>
                 <div className="space-y-2">
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Payment Terms" value={paymentTerms} onChange={e => setPaymentTerms(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Delivery Terms" value={deliveryTerms} onChange={e => setDeliveryTerms(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Lead Time" value={leadTime} onChange={e => setLeadTime(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Warranty" value={warranty} onChange={e => setWarranty(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Liability" value={liability} onChange={e => setLiability(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Cancellation Policy" value={cancellationPolicy} onChange={e => setCancellationPolicy(e.target.value)} />
-                  <input className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Force Majeure" value={forceMajeure} onChange={e => setForceMajeure(e.target.value)} />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Payment Terms"
+                    value={paymentTerms}
+                    onChange={(e) => setPaymentTerms(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Delivery Terms"
+                    value={deliveryTerms}
+                    onChange={(e) => setDeliveryTerms(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Lead Time"
+                    value={leadTime}
+                    onChange={(e) => setLeadTime(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Warranty"
+                    value={warranty}
+                    onChange={(e) => setWarranty(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Liability"
+                    value={liability}
+                    onChange={(e) => setLiability(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Cancellation Policy"
+                    value={cancellationPolicy}
+                    onChange={(e) => setCancellationPolicy(e.target.value)}
+                  />
+                  <input
+                    className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                    placeholder="Force Majeure"
+                    value={forceMajeure}
+                    onChange={(e) => setForceMajeure(e.target.value)}
+                  />
                 </div>
               </div>
               {/* Call to Action Section */}
               <div className="mb-6">
                 <h4 className="text-md font-semibold mb-2">Call to Action</h4>
-                <textarea className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900" placeholder="Next Steps" rows={2} value={nextSteps} onChange={e => setNextSteps(e.target.value)} />
+                <textarea
+                  className="w-full bg-gray-100 border border-gray-300 rounded px-3 py-2 text-gray-900"
+                  placeholder="Next Steps"
+                  rows={2}
+                  value={nextSteps}
+                  onChange={(e) => setNextSteps(e.target.value)}
+                />
               </div>
             </div>
             <div className="flex justify-between">
-              <button type="button" className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded" onClick={() => setActiveTab(5)}>
+              <button
+                type="button"
+                className="bg-gray-100 border border-gray-300 text-gray-500 px-4 py-2 rounded"
+                onClick={() => setActiveTab(5)}
+              >
                 Previous
               </button>
-              <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded" disabled={isSubmitting}>
+              <button
+                type="submit"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded"
+                disabled={isSubmitting}
+              >
                 {isSubmitting ? "Saving..." : "Save Quotation"}
               </button>
             </div>

--- a/src/components/QuoteList.tsx
+++ b/src/components/QuoteList.tsx
@@ -2,6 +2,7 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useState } from "react";
 import { Id } from "../../convex/_generated/dataModel";
+import { PageHeader } from "./PageHeader";
 
 interface QuoteListProps {
   onCreateNew: () => void;
@@ -10,7 +11,7 @@ interface QuoteListProps {
 export function QuoteList({ onCreateNew }: QuoteListProps) {
   const quotes = useQuery(api.quotes.list);
   const updateStatus = useMutation(api.quotes.updateStatus);
-  const [selectedStatus, setSelectedStatus] = useState<string>('all');
+  const [selectedStatus, setSelectedStatus] = useState<string>("all");
 
   if (quotes === undefined) {
     return (
@@ -20,40 +21,47 @@ export function QuoteList({ onCreateNew }: QuoteListProps) {
     );
   }
 
-  const filteredQuotes = selectedStatus === 'all' 
-    ? quotes 
-    : quotes.filter(quote => quote.status === selectedStatus);
+  const filteredQuotes =
+    selectedStatus === "all"
+      ? quotes
+      : quotes.filter((quote) => quote.status === selectedStatus);
 
-  const handleStatusChange = async (quoteId: Id<"quotes">, newStatus: string) => {
+  const handleStatusChange = async (
+    quoteId: Id<"quotes">,
+    newStatus: string,
+  ) => {
     try {
       await updateStatus({ quoteId, status: newStatus as any });
     } catch (error) {
-      console.error('Failed to update status:', error);
+      console.error("Failed to update status:", error);
     }
   };
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'draft': return 'bg-gray-100 text-gray-800';
-      case 'sent': return 'bg-blue-100 text-blue-800';
-      case 'approved': return 'bg-green-100 text-green-800';
-      case 'converted': return 'bg-green-100 text-green-800';
-      case 'rejected': return 'bg-red-100 text-red-800';
-      default: return 'bg-yellow-100 text-yellow-800';
+      case "draft":
+        return "bg-gray-100 text-gray-800";
+      case "sent":
+        return "bg-blue-100 text-blue-800";
+      case "approved":
+        return "bg-green-100 text-green-800";
+      case "converted":
+        return "bg-green-100 text-green-800";
+      case "rejected":
+        return "bg-red-100 text-red-800";
+      default:
+        return "bg-yellow-100 text-yellow-800";
     }
   };
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold text-gray-900">Quotes</h2>
-        <button
-          onClick={onCreateNew}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
-        >
-          Create New Quote
-        </button>
-      </div>
+      <PageHeader
+        title="Quotes"
+        buttonLabel="Create New Quote"
+        icon="add"
+        onButtonClick={onCreateNew}
+      />
 
       {/* Filters */}
       <div className="bg-white p-4 rounded-lg shadow">
@@ -117,8 +125,10 @@ export function QuoteList({ onCreateNew }: QuoteListProps) {
                   ${quote.totalAmount.toLocaleString()}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(quote.status)}`}>
-                    {quote.status.replace('_', ' ')}
+                  <span
+                    className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(quote.status)}`}
+                  >
+                    {quote.status.replace("_", " ")}
                   </span>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
@@ -126,33 +136,39 @@ export function QuoteList({ onCreateNew }: QuoteListProps) {
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   <div className="flex space-x-2">
-                    {quote.status === 'draft' && (
+                    {quote.status === "draft" && (
                       <button
-                        onClick={() => handleStatusChange(quote._id, 'sent')}
+                        onClick={() => handleStatusChange(quote._id, "sent")}
                         className="text-blue-600 hover:text-blue-900"
                       >
                         Send
                       </button>
                     )}
-                    {quote.status === 'sent' && (
+                    {quote.status === "sent" && (
                       <>
                         <button
-                          onClick={() => handleStatusChange(quote._id, 'approved')}
+                          onClick={() =>
+                            handleStatusChange(quote._id, "approved")
+                          }
                           className="text-green-600 hover:text-green-900"
                         >
                           Approve
                         </button>
                         <button
-                          onClick={() => handleStatusChange(quote._id, 'rejected')}
+                          onClick={() =>
+                            handleStatusChange(quote._id, "rejected")
+                          }
                           className="text-red-600 hover:text-red-900"
                         >
                           Reject
                         </button>
                       </>
                     )}
-                    {quote.status === 'approved' && (
+                    {quote.status === "approved" && (
                       <button
-                        onClick={() => handleStatusChange(quote._id, 'converted')}
+                        onClick={() =>
+                          handleStatusChange(quote._id, "converted")
+                        }
                         className="text-green-600 hover:text-green-900"
                       >
                         Convert
@@ -164,7 +180,7 @@ export function QuoteList({ onCreateNew }: QuoteListProps) {
             ))}
           </tbody>
         </table>
-        
+
         {filteredQuotes.length === 0 && (
           <div className="text-center py-12">
             <p className="text-gray-500">No quotes found</p>


### PR DESCRIPTION
## Summary
- create `PageHeader` component for consistent headers with optional action button
- refactor Dashboard, QuoteBuilder, QuoteList, CustomerManager and ProductManager to use `PageHeader`

## Testing
- `npm run lint` *(fails: Cannot find module 'convex/server')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686a3d21d68083299d281cb07bf8ff46